### PR TITLE
PTRv4 deletion code doesn't seem to work

### DIFF
--- a/lib/smart_proxy_dns_dnsmasq/backend/default.rb
+++ b/lib/smart_proxy_dns_dnsmasq/backend/default.rb
@@ -35,12 +35,15 @@ module Proxy::Dns::Dnsmasq
     end
 
     def remove_entry(type, fqdn = nil, ip = nil)
-      return true unless case type
-      when 'A', 'AAAA'
-        e = configuration.find { |entry| entry.is_a?(AddressEntry) && entry.fqdn.include?(fqdn) }
-      when 'PTR'
-        e = configuration.find { |entry| entry.is_a?(PTREntry) && entry.fqdn == fqdn }
-      end
+      e = case type
+            when 'A', 'AAAA'
+              configuration.find { |entry| entry.is_a?(AddressEntry) && entry.fqdn.include?(fqdn) }
+            when 'PTR'
+              configuration.find { |entry| entry.is_a?(PTREntry) && entry.ip.include?(ip.split('.').reverse.join('.')) }
+            else
+              nil
+            end
+      return true unless e
 
       configuration.delete e
       @dirty = true


### PR DESCRIPTION
Hi there!

Just been playing with this on my Raspi Pi-Hole, and it looks like the PTR deletetion code is failing - the A record is removed from the config file, but the PR is not:
```
# cat /etc/dnsmasq.d/99-foreman-dns.conf 
address=/host.that.exists.lan/172.20.10.60
ptr-record=60.10.20.172.in-addr.arpa,host.that.exists.lan
ptr-record=63.10.20.172.in-addr.arpa,testvm.that.is.deleted.lan
```

It seems that the code is trying to match on the forward-written IP rather than the in-arpa address:
```
logger.debug ip.inspect -> "172.20.10.63"
logger.debug configuration_record ->
  <Proxy::Dns::Dnsmasq::Default::PTREntry:0xfb3640
    @ip="63.10.20.172.in-addr.arpa",
    @fqdn="testvm.that.is.deleted.lan"
  >
```

Interestingly, the code in the gem is `e = configuration.find { |entry| entry.is_a?(PTREntry) && entry.ip == ip }` rather than `fqdn`, and the Version string doesn't match either (0.4 vs 0.5 on Rubygems) - is there some unreleased patch that's missing here?

In any case, I've fixed it for matching against the reverse IP address, which seems to work for me. I can look at the tests, but it's probably going to need rewriting so that it can test what's actually in the file. Comments are very welcome!

(BTW, as the Foreman community lead, this & your DHCP Dnsmasq plugins are great! We should talk about getting them into the community space :P)
