### PR TITLE
Switch defaults to restart rather than reload for dnsmasq

### DIFF
--- a/config/dns_dnsmasq.yml
+++ b/config/dns_dnsmasq.yml
@@ -6,4 +6,4 @@
 #
 #:backend: default
 :config_path: /etc/dnsmasq.d/foreman.conf
-:reload_cmd: systemctl reload dnsmasq
+:reload_cmd: systemctl restart dnsmasq

--- a/lib/smart_proxy_dns_dnsmasq/dns_dnsmasq_plugin.rb
+++ b/lib/smart_proxy_dns_dnsmasq/dns_dnsmasq_plugin.rb
@@ -9,7 +9,7 @@ module Proxy::Dns::Dnsmasq
     # An exception will be raised if they are initialized with nil values.
     # Settings not listed under default_settings are considered optional and by default have nil value.
     default_settings :config_path => '/etc/dnsmasq.d/foreman.conf',
-                     :reload_cmd => 'systemctl reload dnsmasq'
+                     :reload_cmd => 'systemctl restart dnsmasq'
 
     requires :dns, '>= 1.15'
 

--- a/test/dns_dnsmasq_default_settings_test.rb
+++ b/test/dns_dnsmasq_default_settings_test.rb
@@ -5,7 +5,7 @@ require 'smart_proxy_dns_dnsmasq/dns_dnsmasq_plugin'
 class DnsDnsmasqDefaultSettingsTest < Test::Unit::TestCase
   def test_default_settings
     Proxy::Dns::Dnsmasq::Plugin.load_test_settings({})
-    assert_equal "default_value", Proxy::Dns::Dnsmasq::Plugin.settings.required_setting
-    assert_equal "/must/exist", Proxy::Dns::Dnsmasq::Plugin.settings.required_path
+    assert_equal "/etc/dnsmasq.d/foreman.conf", Proxy::Dns::Dnsmasq::Plugin.settings[:config_path]
+    assert_equal "systemctl restart dnsmasq", Proxy::Dns::Dnsmasq::Plugin.settings[:reload_cmd]
   end
 end


### PR DESCRIPTION
In my testing, `reload` wasn't enough for Dnsmasq to start replying to the new records - something `dig @<my server> <new A record name>` would just return NXDOMAIN. I had to use `restart` to make it go.

I've updated the defaults, and also fixed the settings tests (which appear to be left over from the template, as they reference settings that aren't in this plugin) - they weren't passing for me before.